### PR TITLE
#299 Admin check for merge sections

### DIFF
--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -9,7 +9,9 @@ interface FeatureDataProps {
   helpURLEnding: string
 }
 
-const adminRoles = [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']]
+const adminRoles: RoleEnum[] = [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']]
+const courseRenameRoles: RoleEnum[] = adminRoles
+const createSectionRoles: RoleEnum[] = [RoleEnum.Teacher, ...adminRoles]
 
 const mergeSectionProps: FeatureDataProps = {
   id: 'MergeSections',
@@ -65,11 +67,8 @@ const addNonUMUsersProps: FeatureDataProps = {
   helpURLEnding: '/add-non-um-users.html'
 }
 
-const courseRenameRoles: RoleEnum[] = adminRoles
-const createSectionRoles: RoleEnum[] = [RoleEnum.Teacher, ...adminRoles]
-
 export type { FeatureDataProps }
 export {
   mergeSectionProps, formatCanvasGradebookProps, formatThirdPartyGradebookProps,
-  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles, createSectionRoles
+  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles, createSectionRoles, adminRoles
 }

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -5,11 +5,11 @@ import { Button, Grid, LinearProgress, makeStyles, Typography } from '@material-
 import { useSnackbar } from 'notistack'
 
 import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
+import { adminRoles } from '../models/feature'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import { CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort } from '../models/canvas'
 import { mergeSections } from '../api'
 import usePromise from '../hooks/usePromise'
-import { RoleEnum } from '../models/models'
 import { CourseNameSearcher, CourseSectionSearcher, SectionNameSearcher, UniqnameSearcher } from '../utils/SectionSearcher'
 import CourseSectionList from '../components/CourseSectionList'
 import Help from '../components/Help'
@@ -126,8 +126,8 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
     }
   }
 
-  const isSubAccountAdminOrAccountAdmin = (): boolean => {
-    return isAuthorizedForRoles([RoleEnum['Subaccount admin'], RoleEnum['Account Admin']], props.globals.course.roles)
+  const isAdmin = (): boolean => {
+    return isAuthorizedForRoles(adminRoles, props.globals.course.roles)
   }
 
   const stageSections = (): void => {
@@ -158,7 +158,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
             ]
           }
         }}
-        search={ isSubAccountAdminOrAccountAdmin() ? [new CourseNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle), new UniqnameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)] : [new SectionNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)]}
+        search={ isAdmin() ? [new CourseNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle), new UniqnameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)] : [new SectionNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)]}
         multiSelect={true}
         showCourseName={true}
         sections={unstagedSections !== undefined ? unstagedSections : []}
@@ -186,7 +186,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
           selectedSections={selectedStagedSections}
           selectionUpdated={setSelectedStagedSections}
           sectionsRemoved={handleUnmergedSections}
-          canUnmerge={isSubAccountAdminOrAccountAdmin()}
+          canUnmerge={isAdmin()}
           highlightUnlocked={true}
           ></SectionSelectorWidget>
       </div>
@@ -223,7 +223,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const getMergeSuccess = (): JSX.Element => {
-    return (<CourseSectionList canUnmerge={isSubAccountAdminOrAccountAdmin()} {...props}/>)
+    return (<CourseSectionList canUnmerge={isAdmin()} {...props}/>)
   }
 
   return (


### PR DESCRIPTION
Fixes #299
I found a bug when testing your PR where `Support consultant` cannot search by course name and Uniqname for Merge Section, Bizarre!  I know when we merged the Merge section feature that was True. I don't know how that is broken.  

**You did not introduce this bug with this branch.**

You created a const called `adminRoles` and I felt I can reuse that for fixing this bug. Let me know if you don't like this idea I can open a separate PR once your PR get merged [#298](https://github.com/tl-its-umich-edu/canvas-course-manager-next/pull/298)